### PR TITLE
Force status update if user is outdated

### DIFF
--- a/Trackovid19-web/src/app/screens/main/main.component.ts
+++ b/Trackovid19-web/src/app/screens/main/main.component.ts
@@ -64,13 +64,11 @@ export class MainComponent implements OnInit, OnDestroy {
     this.subs.unsubscribe();
   }
 
-  private loadUser() {
-    this.subs.add(
-      this.userService.getUser().subscribe(user => {
-        this.user = { ...user };
-        this.loadState();
-      }),
-    );
+  private hasUserOutdatedStatus(lastUpdate) {
+    const oneDayBehindTime = new Date().getTime() - 1 * 24 * 60 * 60 * 1000; // 1day 24hour  60min  60sec  1000msec
+    const lastUpdateTime = new Date(lastUpdate).getTime(); // we need the timestamp to match the difference
+
+    return oneDayBehindTime > lastUpdateTime;
   }
 
   private loadState() {
@@ -78,6 +76,19 @@ export class MainComponent implements OnInit, OnDestroy {
       this.conditionService.get().subscribe((states: any[]) => {
         this.confinementState =
           states.find(state => state.id === +this.user.confinement_state) || null;
+      }),
+    );
+  }
+
+  private loadUser() {
+    this.subs.add(
+      this.userService.getUser().subscribe(user => {
+        this.user = { ...user };
+        this.loadState();
+
+        if (this.hasUserOutdatedStatus(user.updated_at)) {
+          this.router.navigate(['/dashboard', 'change-state-step1']);
+        }
       }),
     );
   }


### PR DESCRIPTION
Description: When the user is logged in, we need to check if the last status was > 24h before. If true, we should redirect him to update-status page

Changes: When we load the user on the main component, we will check if he is outdated. If true, we'll send him to update-status panel 