### PR TITLE
Remove duplicated twitter share url

### DIFF
--- a/Trackovid19-web/src/app/shared/share-status/share-status.component.ts
+++ b/Trackovid19-web/src/app/shared/share-status/share-status.component.ts
@@ -90,7 +90,6 @@ export class ShareStatusComponent implements OnInit {
   shareTwitter() {
     const twitterWindow = window.open(
       `https://twitter.com/intent/tweet?via=covidografia&` +
-        `url=${this.video.share.twitter}&` +
         `text=${this.shareText}&hashtags=${this.hashtag}`,
       'height=350,width=600',
     );


### PR DESCRIPTION
Remove unnecessary URL on twitter share link  because we already have that inside `shareText`