### PR TITLE
feat(pwa): skip update dialog and update start url

### DIFF
--- a/Trackovid19-web/src/app/app.component.ts
+++ b/Trackovid19-web/src/app/app.component.ts
@@ -33,9 +33,7 @@ export class AppComponent {
     //TODO: Check if we want to go with this or not
     if (this.swUpdate.isEnabled) {
       this.swUpdate.available.subscribe(() => {
-        if (confirm('New version available. Load New Version?')) {
-          window.location.reload();
-        }
+        window.location.reload();
       });
     }
   }

--- a/Trackovid19-web/src/manifest.webmanifest
+++ b/Trackovid19-web/src/manifest.webmanifest
@@ -6,8 +6,8 @@
     "background_color": "#ffffff",
     "lang": "pt",
     "display": "standalone",
-    "scope": "./",
-    "start_url": "./?source=a2hs",
+    "scope": "/",
+    "start_url": "/#/dashboard/status?source=a2hs",
     "categories": ["health"],
     "icons": [
         {


### PR DESCRIPTION
This removes the `'New version available. Load New Version?'` dialog confirmation and updates the PWA start URL to the dashboard page.

fix #343 