### PR TITLE
Performance - Remove not needed font-awesome

### DIFF
--- a/Trackovid19-web/src/app/shared/profile/profile.component.html
+++ b/Trackovid19-web/src/app/shared/profile/profile.component.html
@@ -9,7 +9,9 @@
   </ng-container>
 
   <ng-template #loading>
-    <i class="fa fa-circle-o-notch fa-spin"></i>
+    <div class="loading">
+      <div class="lds-heart"><div></div></div>
+    </div>
   </ng-template>
   <!-- <img class="profile_dgs_logo" src="assets/img/logo/covidografia.svg" />
   <img src="assets/img/share.svg" /> -->

--- a/Trackovid19-web/src/app/shared/profile/profile.component.scss
+++ b/Trackovid19-web/src/app/shared/profile/profile.component.scss
@@ -50,3 +50,66 @@
     }
   }
 }
+
+// Loading
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+
+  .lds-heart {
+    display: inline-block;
+    position: relative;
+    width: 40px;
+    height: 40px;
+    transform: rotate(45deg);
+    transform-origin: 20px 20px;
+  }
+  .lds-heart div {
+    top: 16px;
+    left: 16px;
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    background: #fa6400;
+    animation: lds-heart 1.2s infinite cubic-bezier(0.215, 0.61, 0.355, 1);
+  }
+  .lds-heart div:after,
+  .lds-heart div:before {
+    content: ' ';
+    position: absolute;
+    display: block;
+    width: 16px;
+    height: 16px;
+    background: #fa6400;
+  }
+  .lds-heart div:before {
+    left: -12px;
+    border-radius: 50% 0 0 50%;
+  }
+  .lds-heart div:after {
+    top: -12px;
+    border-radius: 50% 50% 0 0;
+  }
+  @keyframes lds-heart {
+    0% {
+      transform: scale(0.95);
+    }
+    5% {
+      transform: scale(1.1);
+    }
+    39% {
+      transform: scale(0.85);
+    }
+    45% {
+      transform: scale(1);
+    }
+    60% {
+      transform: scale(0.95);
+    }
+    100% {
+      transform: scale(0.9);
+    }
+  }
+}

--- a/Trackovid19-web/src/index.html
+++ b/Trackovid19-web/src/index.html
@@ -13,12 +13,6 @@
     <link rel="mask-icon" href="assets/img/favicon/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
-    <link
-      href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
-      rel="stylesheet"
-      integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
-      crossorigin="anonymous"
-    />
     <!-- Google Tag Manager -->
     <script>
       (function(w, d, s, l, i) {


### PR DESCRIPTION
Remove font-awesome, since we were including it, just for an icon. Less 7KB GZIP on bundle size.

Changed to this, just CSS.

[![Image from Gyazo](https://i.gyazo.com/c2bdd4756929cbcfe5c3cef871cdde5b.gif)](https://gyazo.com/c2bdd4756929cbcfe5c3cef871cdde5b)