### PR TITLE
Fix share location status button layout on desktop

### DIFF
--- a/Trackovid19-web/src/app/screens/main/main.component.scss
+++ b/Trackovid19-web/src/app/screens/main/main.component.scss
@@ -93,7 +93,7 @@
   border-radius: 2.5rem;
   outline: none;
   cursor: pointer;
-  padding: 1.125rem 2.5rem;
+  padding: 1.125rem;
   margin: 0 12px;
   border: 1px solid #fa6400;
   font-size: 13px;
@@ -105,6 +105,8 @@
 
 .share-status.display_desktop {
   margin: 0;
+  width: 100%;
+  justify-content: center;
 }
 
 /*


### PR DESCRIPTION
In production:
![Screen Shot 2020-04-07 at 20 50 15](https://user-images.githubusercontent.com/1127990/78713330-034d6f00-7912-11ea-9b7c-8cab862a017d.png)

After fix:
![Screen Shot 2020-04-07 at 20 55 14](https://user-images.githubusercontent.com/1127990/78713400-2415c480-7912-11ea-8da1-dd61f4bb9650.png)
